### PR TITLE
feat: aws-kms submodule example

### DIFF
--- a/examples/aws-kms-key-complete/README.md
+++ b/examples/aws-kms-key-complete/README.md
@@ -1,0 +1,83 @@
+# encryption-at-rest-aws-kms-key - complete example
+
+_Note: you can see the full source code in the [github repository](https://github.com/terraform-mongodbatlas-modules/terraform-mongodbatlas-encryption-at-rest/tree/main/examples/aws-kms-key-complete)_
+
+This example sets up encryption at rest using an AWS KMS for your Atlas Project. It creates the encryption key in AWS KMS, an IAM role and policy so that Atlas can access the key, and enables encryption at rest for the Atlas Project. Finally, it creates a Cluster with encryption at rest enabled.
+
+## Usage
+
+- Set the following variable: 
+
+    - `project_id`: ID of the Atlas project
+
+- Set the following environment variables:
+
+    -  `export MONGODB_ATLAS_PUBLIC_KEY="<YOUR_PUBLIC_KEY>"`
+    -  `export MONGODB_ATLAS_PRIVATE_KEY="<YOUR_PRIVATE_KEY>"`
+    -  `export AWS_ACCESS_KEY_ID="<YOUR_ACCESS_KEY>"`
+    -  `export AWS_SECRET_ACCESS_KEY="<YOUR_SECRET_KEY>"`
+    -  `export AWS_REGION="<YOUR_REGION>"`
+
+- Run the following command to initialize your project:
+
+```bash
+$ terraform init
+```
+
+- Run the following command to review the execution plan:
+
+```bash
+$ terraform plan
+```
+
+- Run the following command to deploy your infrastructure:
+
+```bash
+$ terraform apply
+```
+
+## Considerations
+
+- In order to define the AWS KMS Key policy with the correct permissions, it should look like this:
+
+```terraform
+{
+  "Statement": [
+      // other statements
+      {
+          "Sid": "Allow use of the key by specific IAM user",
+          "Action": [
+              "kms:Decrypt",
+              "kms:Encrypt",
+              "kms:DescribeKey"
+          ],
+          "Effect": "Allow",
+          "Principal": {
+              "AWS": "*"
+          },
+          "Resource": "*",
+          "Condition": {
+              "StringEquals": {
+                  "aws:PrincipalArn": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE" // optional clause to limit to your execution role only
+              }
+          }
+      }
+  ],
+  "Version": "2012-10-17"
+}
+```
+
+- If you want more information on how to enable encryption at rest in your cluster, refer to this [blog post](https://www.mongodb.com/docs/atlas/security-kms-encryption/).
+
+## Resources
+
+The module creates the following resources:
+
+| Name | Type |
+|------|------|
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
+| [mongodbatlas_encryption_at_rest](https://registry.terraform.io/providers/mongodb/mongodbatlas/1.17.6/docs/resources/encryption_at_rest) | resource |
+| [mongodbatlas_cloud_provider_access_setup](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_provider_access#mongodbatlas_cloud_provider_access_setup) | resource |
+| [mongodbatlas_cloud_provider_access_authorization](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_provider_access#mongodbatlas_cloud_provider_access_authorization) | resource |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |

--- a/examples/aws-kms-key-complete/README.md
+++ b/examples/aws-kms-key-complete/README.md
@@ -47,32 +47,43 @@ $ terraform apply
 
 ```terraform
 {
-  "Statement": [
-      // other statements
+  "Version": "2012-10-17",
+    "Id": "key-default-1",
+    "Statement": [
       {
-          "Sid": "Allow use of the key by specific IAM user",
-          "Action": [
-              "kms:Decrypt",
-              "kms:Encrypt",
-              "kms:DescribeKey"
-          ],
-          "Effect": "Allow",
-          "Principal": {
-              "AWS": "*"
-          },
-          "Resource": "*",
-          "Condition": {
-              "StringEquals": {
-                  "aws:PrincipalArn": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE"
-              }
+        "Sid": "Allow administration of the key",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::{AWS_ACCOUNT}:root"
+        },
+        "Action": [
+          "kms:*"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "Allow use of the key by specific IAM user",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": module.aws-kms-key.role_arn
+        },
+        "Action": [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:DescribeKey"
+        ],
+        "Resource": "*",
+        "Condition" : {
+          "StringEquals" : {
+            "aws:PrincipalArn": module.aws-kms-key.role_arn
           }
+        }
       }
-  ],
-  "Version": "2012-10-17"
+    ]
 }
 ```
 
-_Note: the IAM Role ARN used in the aws:PrincipalArn attribute is the one created in the submodule._
+_Note: the IAM Role ARN used is the one created in the submodule._
 
 - If you want more information on how to enable encryption at rest in your cluster, refer to this [blog post](https://www.mongodb.com/docs/atlas/security-kms-encryption/).
 

--- a/examples/aws-kms-key-complete/README.md
+++ b/examples/aws-kms-key-complete/README.md
@@ -2,13 +2,17 @@
 
 _Note: you can see the full source code in the [github repository](https://github.com/terraform-mongodbatlas-modules/terraform-mongodbatlas-encryption-at-rest/tree/main/examples/aws-kms-key-complete)_
 
-This example sets up encryption at rest using an AWS KMS for your Atlas Project. It creates the encryption key in AWS KMS, an IAM role and policy so that Atlas can access the key, and enables encryption at rest for the Atlas Project. Finally, it creates a Cluster with encryption at rest enabled.
+This example sets up encryption at rest using an AWS KMS for your Atlas Project. Specifically, it does the following: 
+- Creates encryption key in AWS KMS.
+- Creates an IAM role and policy so that Atlas can access the key.
+- Enables encryption at rest for the Atlas Project.
+- Creates a Cluster with encryption at rest enabled.
 
 ## Usage
 
 - Set the following variable: 
 
-    - `project_id`: ID of the Atlas project
+    - `project_id`: Unique 24-hexadecimal character string that identifies the Atlas project
 
 - Set the following environment variables:
 
@@ -38,7 +42,7 @@ $ terraform apply
 
 ## Considerations
 
-- In order to define the AWS KMS Key policy with the correct permissions, it should look like this:
+- Your AWS KMS Key policy must allow the IAM Role access, this can be done by::
 
 ```terraform
 {
@@ -58,7 +62,7 @@ $ terraform apply
           "Resource": "*",
           "Condition": {
               "StringEquals": {
-                  "aws:PrincipalArn": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE" // optional clause to limit to your execution role only
+                  "aws:PrincipalArn": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE"
               }
           }
       }

--- a/examples/aws-kms-key-complete/README.md
+++ b/examples/aws-kms-key-complete/README.md
@@ -72,6 +72,8 @@ $ terraform apply
 }
 ```
 
+_Note: the IAM Role ARN used in the aws:PrincipalArn attribute is the one created in the submodule._
+
 - If you want more information on how to enable encryption at rest in your cluster, refer to this [blog post](https://www.mongodb.com/docs/atlas/security-kms-encryption/).
 
 ## Resources

--- a/examples/aws-kms-key-complete/README.md
+++ b/examples/aws-kms-key-complete/README.md
@@ -4,8 +4,9 @@ _Note: you can see the full source code in the [github repository](https://githu
 
 This example sets up encryption at rest using an AWS KMS for your Atlas Project. Specifically, it does the following: 
 - Creates encryption key in AWS KMS.
-- Creates an IAM role and policy so that Atlas can access the key.
-- Enables encryption at rest for the Atlas Project.
+- Using the aws-kms submodule:
+    - Creates an IAM role and policy so that Atlas can access the key.
+    - Enables encryption at rest for the Atlas Project.
 - Creates a Cluster with encryption at rest enabled.
 
 ## Usage
@@ -42,7 +43,7 @@ $ terraform apply
 
 ## Considerations
 
-- Your AWS KMS Key policy must allow the IAM Role access, this can be done by::
+- Your AWS KMS Key policy should allow the IAM Role access. The following is an example of how to provide this permission:
 
 ```terraform
 {

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -1,5 +1,31 @@
 resource "aws_kms_key" "key" {
   description = "MongoDB Atlas KMS key."
+  policy      = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Id": "key-default-1",
+    "Statement": [
+      {
+        "Sid": "Allow use of the key by specific IAM user",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE"
+        },
+        "Action": [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:DescribeKey"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringEquals": {
+              "aws:PrincipalArn": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE"
+          }
+        }
+      }
+    ]
+  }
+  EOF
 }
 
 module "aws-kms-key" {
@@ -30,5 +56,5 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   }
 
-  depends_on = [ module.aws-kms-key ]
+  depends_on = [module.aws-kms-key]
 }

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -1,0 +1,32 @@
+resource "aws_kms_key" "key" {
+  description = "MongoDB Atlas KMS key."
+}
+
+module "aws-kms-key" {
+  source        = "../../modules/aws-kms"
+  project_id      = var.project_id
+  aws_kms_key_arn = aws_kms_key.key.arn
+  iam_role_name = "iam-role-example-name"
+  iam_role_policy_name = "iam-role-policy-example-name"
+  kms_key_region  = "US_EAST_2" # assuming the KMS key was created in AWS region us-east-2
+}
+
+resource "mongodbatlas_advanced_cluster" "cluster" {
+  project_id                  = var.project_id
+  name                        = "MyCluster"
+  cluster_type                = "REPLICASET"
+  backup_enabled              = true
+  encryption_at_rest_provider = "AWS"
+
+  replication_specs {
+    region_configs {
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_EAST_2"
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+    }
+  }
+}

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -29,4 +29,6 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       }
     }
   }
+
+  depends_on = [ module.aws-kms-key ]
 }

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -9,7 +9,7 @@ resource "aws_kms_key" "key" {
         "Sid": "Allow use of the key by specific IAM user",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE"
+          "AWS": ${module.aws-kms-key.role_arn}
         },
         "Action": [
           "kms:Decrypt",
@@ -19,7 +19,7 @@ resource "aws_kms_key" "key" {
         "Resource": "*",
         "Condition": {
           "StringEquals": {
-              "aws:PrincipalArn": "arn:aws:iam::{ACCOUNT}:role/IAM_EXECUTION_ROLE"
+              "aws:PrincipalArn": ${module.aws-kms-key.role_arn}
           }
         }
       }

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -1,35 +1,35 @@
 resource "aws_kms_key" "key" {
   description = "MongoDB Atlas KMS key."
-  policy = jsonencode ({
-    "Version": "2012-10-17",
-    "Id": "key-default-1",
-    "Statement": [
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Id" : "key-default-1",
+    "Statement" : [
       {
-        "Sid": "Allow administration of the key",
-        "Effect": "Allow",
-        "Principal": {
-          "AWS": "arn:aws:iam::{AWS_ACCOUNT}:root"
+        "Sid" : "Allow administration of the key",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "arn:aws:iam::{AWS_ACCOUNT}:root"
         },
-        "Action": [
+        "Action" : [
           "kms:*"
         ],
-        "Resource": "*"
+        "Resource" : "*"
       },
       {
-        "Sid": "Allow use of the key by specific IAM user",
-        "Effect": "Allow",
-        "Principal": {
-          "AWS": module.aws-kms-key.role_arn
+        "Sid" : "Allow use of the key by specific IAM user",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : module.aws-kms-key.role_arn
         },
-        "Action": [
+        "Action" : [
           "kms:Decrypt",
           "kms:Encrypt",
           "kms:DescribeKey"
         ],
-        "Resource": "*",
+        "Resource" : "*",
         "Condition" : {
           "StringEquals" : {
-            "aws:PrincipalArn": module.aws-kms-key.role_arn
+            "aws:PrincipalArn" : module.aws-kms-key.role_arn
           }
         }
       }

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -3,12 +3,12 @@ resource "aws_kms_key" "key" {
 }
 
 module "aws-kms-key" {
-  source        = "../../modules/aws-kms"
-  project_id      = var.project_id
-  aws_kms_key_arn = aws_kms_key.key.arn
-  iam_role_name = "iam-role-example-name"
+  source               = "../../modules/aws-kms"
+  project_id           = var.project_id
+  aws_kms_key_arn      = aws_kms_key.key.arn
+  iam_role_name        = "iam-role-example-name"
   iam_role_policy_name = "iam-role-policy-example-name"
-  kms_key_region  = "US_EAST_2" # assuming the KMS key was created in AWS region us-east-2
+  kms_key_region       = "US_EAST_2" # assuming the KMS key was created in AWS region us-east-2
 }
 
 resource "mongodbatlas_advanced_cluster" "cluster" {

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -1,15 +1,25 @@
 resource "aws_kms_key" "key" {
   description = "MongoDB Atlas KMS key."
-  policy      = <<-EOF
-  {
+  policy = jsonencode ({
     "Version": "2012-10-17",
     "Id": "key-default-1",
     "Statement": [
       {
+        "Sid": "Allow administration of the key",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::{AWS_ACCOUNT}:root"
+        },
+        "Action": [
+          "kms:*"
+        ],
+        "Resource": "*"
+      },
+      {
         "Sid": "Allow use of the key by specific IAM user",
         "Effect": "Allow",
         "Principal": {
-          "AWS": ${module.aws-kms-key.role_arn}
+          "AWS": module.aws-kms-key.role_arn
         },
         "Action": [
           "kms:Decrypt",
@@ -17,15 +27,14 @@ resource "aws_kms_key" "key" {
           "kms:DescribeKey"
         ],
         "Resource": "*",
-        "Condition": {
-          "StringEquals": {
-              "aws:PrincipalArn": ${module.aws-kms-key.role_arn}
+        "Condition" : {
+          "StringEquals" : {
+            "aws:PrincipalArn": module.aws-kms-key.role_arn
           }
         }
       }
     ]
-  }
-  EOF
+  })
 }
 
 module "aws-kms-key" {

--- a/examples/aws-kms-key-complete/provider.tf
+++ b/examples/aws-kms-key-complete/provider.tf
@@ -1,0 +1,5 @@
+provider "mongodbatlas" {
+}
+
+provider "aws" {
+}

--- a/examples/aws-kms-key-complete/variables.tf
+++ b/examples/aws-kms-key-complete/variables.tf
@@ -1,0 +1,4 @@
+variable "project_id" {
+  description = "The project id (e.g., 65def6ce0f722a1507105bb5)."
+  type        = string
+}

--- a/examples/aws-kms-key-complete/versions.tf
+++ b/examples/aws-kms-key-complete/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
## Description

Added an example for the aws-kms submodule of the encryption-at-rest module.

<img width="1290" alt="Screenshot 2024-08-16 at 17 12 52" src="https://github.com/user-attachments/assets/df85cf8d-2ecd-4de4-8cf0-deaa87e327a7">

