### PR TITLE
feat: update paths and key arn secret instead of variable

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -25,7 +25,7 @@ jobs:
             MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.MONGODB_ATLAS_PRIVATE_KEY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }} 
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            TF_VAR_aws_kms_key_arn: ${{ vars.TF_VAR_AWS_KMS_KEY_ARN }}
+            TF_VAR_aws_kms_key_arn: ${{ secrets.TF_VAR_AWS_KMS_KEY_ARN }}
 
         run: |
             cd ./modules/aws-kms

--- a/examples/aws-kms-key-complete/main.tf
+++ b/examples/aws-kms-key-complete/main.tf
@@ -38,7 +38,7 @@ resource "aws_kms_key" "key" {
 }
 
 module "aws-kms-key" {
-  source               = "../../modules/aws-kms"
+  source               = "terraform-mongodbatlas-modules/encryption-at-rest/mongodbatlas//modules/aws-kms"
   project_id           = var.project_id
   aws_kms_key_arn      = aws_kms_key.key.arn
   iam_role_name        = "iam-role-example-name"

--- a/modules/aws-kms/README.md
+++ b/modules/aws-kms/README.md
@@ -10,7 +10,7 @@ It creates the resources to perform the following actions:
 - Authorize MongoDB Atlas for Cloud Provider Access.
 - Enable Encryption at Rest in the Atlas project.
 
-You can find detailed information of the submodule's input and output variables in the [Terraform Public Registry]()
+You can find detailed information of the submodule's input and output variables in the [Terraform Public Registry](https://registry.terraform.io/modules/terraform-mongodbatlas-modules/encryption-at-rest/mongodbatlas/latest)
 
 ## Usage 
 
@@ -40,7 +40,9 @@ The module creates the following resources:
 | [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 
+
 -> **NOTE:** Encryption at rest can only be enabled once per project.
+
 
 For more information, see the [MongoDB Atlas](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs) and [AWS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) Terraform providers documentation.
 

--- a/modules/aws-kms/tests/README.md
+++ b/modules/aws-kms/tests/README.md
@@ -9,6 +9,7 @@
     -  `export TF_VAR_org_id=<YOUR_ORG_ID>`
     -  `export AWS_ACCESS_KEY_ID="<YOUR_ACCESS_KEY>"`
     -  `export AWS_SECRET_ACCESS_KEY="<YOUR_SECRET_KEY>"`
+    -  `export TF_VAR_aws_kms_key_arn="<YOUR_KMS_KEY_ARN>"`
 
 3. Run from terminal the command `cd modules/aws-kms`
 


### PR DESCRIPTION
## Description

- Updated the paths in the example and documentation to reference the public registry.
- Now the aws kms key arn is a github secret, not a variable.
