### PR TITLE
feat: nightly tests encryption at rest module

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "*/10 * * * *" # this is a temporary scheduling that runs every 10 min to test that the slack notification is sent correctly. Once we verify it, the scheduling will be every day at midnight
+    - cron: "0 0 * * *" # every day at midnight
 
 jobs:
   tf-test:
@@ -69,5 +69,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_TEST }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description

Nightly tests for the encryption at rest module. They will run everyday at midnight. A message to the slack channel will only be sent if the scheduled tests fail. 
